### PR TITLE
Resetting indices for joint_df

### DIFF
--- a/src/pyace/preparedata.py
+++ b/src/pyace/preparedata.py
@@ -674,7 +674,7 @@ class ACEDataset:
             # for joint train+test
             self.fitting_data["train"] = True
             self.test_data["train"] = False
-            joint_df = pd.concat([self.fitting_data, self.test_data], axis=0)
+            joint_df = pd.concat([self.fitting_data, self.test_data], axis=0).reset_index(drop = True)
             joint_df = apply_weights(joint_df, self.weighting_policy_spec, self.ignore_weights)
             self.fitting_data = joint_df.query("train").reset_index(drop=True)
             self.test_data = joint_df.query("~train").reset_index(drop=True)


### PR DESCRIPTION
There is a bug when using loading a separate testing dataframe when adding the Energy based weights, it duplicates the structure due to having the same indices repeated. 

For example, 

My training dataframe had 4500 configurations while the testing dataframe had 4111 configurations, combined they are 8611 configurations. The saved datasets with weights would have duplicate entries and it would be nearly double the size of the dataframe.

The suggested fix is to simply reset the indices for the joint dataframe before applying the weights.